### PR TITLE
Changes toolCoord2Isocoord to generate message for the calling function

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2455090'
+ValidationKey: '2475868'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   mstools: Tool functions that can be used by several madrat-dependent or
       magpie4 output functions
-version: 0.12.1
-date-released: '2025-07-21'
+version: 0.12.2
+date-released: '2025-07-25'
 abstract: Tool functions that can be used by several madrat-dependent or magpie4 output
   functions.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: mstools
 Title: Tool functions that can be used by several madrat-dependent or
     magpie4 output functions
-Version: 0.12.1
-Date: 2025-07-21
+Version: 0.12.2
+Date: 2025-07-25
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Kristine", "Karstens", role = "aut"),

--- a/R/toolCoord2Isocoord.R
+++ b/R/toolCoord2Isocoord.R
@@ -16,7 +16,8 @@ toolCoord2Isocoord <- function(x) {
   mstools::toolExpectTrue(
     magclass::hasCoords(x),
     "has coordinate data (called `x` and `y`)",
-    falseStatus = "note"
+    falseStatus = "note",
+    level = 1
   )
 
   # Remove all spatial dimensions except x and y, ensure they're correctly named
@@ -34,7 +35,8 @@ toolCoord2Isocoord <- function(x) {
   mstools::toolExpectTrue(
     !(any(is.na(matches))),
     "all spatial dimensions can be mapped to ISO", # invalid dimensions are just removed, so this is only a note
-    falseStatus = "note"
+    falseStatus = "note",
+    level = 1
   )
 
   # Append iso to coordinates of x
@@ -45,7 +47,8 @@ toolCoord2Isocoord <- function(x) {
   mstools::toolExpectTrue(
     dim(x)[1] == 67420,
     "magclass object conforms to standard 67420 cell size",
-    falseStatus = "note"
+    falseStatus = "note",
+    level = 1
   )
 
   # Arrange spatial dimension of x to match the mapping

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tool functions that can be used by several madrat-dependent or
     magpie4 output functions
 
-R package **mstools**, version **0.12.1**
+R package **mstools**, version **0.12.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mstools)](https://cran.r-project.org/package=mstools) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/mstools)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **mstools** in publications use:
 
-Bodirsky B, Karstens K, Beier F, Dietrich J (2025). "mstools: Tool functions that can be used by several madrat-dependent or magpie4 output functions." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 0.12.1, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Karstens K, Beier F, Dietrich J (2025). "mstools: Tool functions that can be used by several madrat-dependent or magpie4 output functions." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 0.12.2, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,9 +50,9 @@ A BibTeX entry for LaTeX users is
     magpie4 output functions},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Felicitas Beier and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.1158582},
-  date = {2025-07-21},
+  date = {2025-07-25},
   year = {2025},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 0.12.1},
+  note = {Version: 0.12.2},
 }
 ```


### PR DESCRIPTION
As the level was not set, the `toolExpectTrue` assumes that it is used in a proper domain function. By setting `level = 1` we tell it that it is used inside another tool function and should look further up for the function name.