### PR TITLE
pmin/pmax migration

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2475868'
+ValidationKey: '2499360'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -5,6 +5,6 @@ AcceptedWarnings:
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 AcceptedNotes: ~
 allowLinterWarnings: yes
-enforceVersionUpdate: no
+enforceVersionUpdate: yes
 skipCoverage: no
 AutocreateCITATION: yes

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   mstools: Tool functions that can be used by several madrat-dependent or
       magpie4 output functions
-version: 0.12.2
-date-released: '2025-07-25'
+version: 0.12.3
+date-released: '2025-08-20'
 abstract: Tool functions that can be used by several madrat-dependent or magpie4 output
   functions.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: mstools
 Title: Tool functions that can be used by several madrat-dependent or
     magpie4 output functions
-Version: 0.12.2
-Date: 2025-07-25
+Version: 0.12.3
+Date: 2025-08-20
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Kristine", "Karstens", role = "aut"),

--- a/R/toolFertilizerDistribution.R
+++ b/R/toolFertilizerDistribution.R
@@ -58,7 +58,7 @@ toolFertilizerDistribution <- function(iterMax = 50, maxSnupe = 0.85, fertilizer
     required[is.nan(required)] <- 0
 
     # - split organic into usable vs. excessive
-    excessiveOrganic <- pmax(0, organicinputs - required)
+    excessiveOrganic <- pmax(organicinputs - required, 0)
     usableOrganic <- organicinputs - excessiveOrganic
 
     # - compute surplus fertilizer gap

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tool functions that can be used by several madrat-dependent or
     magpie4 output functions
 
-R package **mstools**, version **0.12.2**
+R package **mstools**, version **0.12.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mstools)](https://cran.r-project.org/package=mstools) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/mstools)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **mstools** in publications use:
 
-Bodirsky B, Karstens K, Beier F, Dietrich J (2025). "mstools: Tool functions that can be used by several madrat-dependent or magpie4 output functions." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 0.12.2, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Karstens K, Beier F, Dietrich J (2025). "mstools: Tool functions that can be used by several madrat-dependent or magpie4 output functions." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 0.12.3, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,9 +50,9 @@ A BibTeX entry for LaTeX users is
     magpie4 output functions},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Felicitas Beier and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.1158582},
-  date = {2025-07-25},
+  date = {2025-08-20},
   year = {2025},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 0.12.2},
+  note = {Version: 0.12.3},
 }
 ```


### PR DESCRIPTION
This PR only slightly changes a single call to pmax. It swapgs the arguments to ensure that the return type matches the type of the first argument, otherwise the return value will be a numeric vector, which might be unexpected.